### PR TITLE
Add rotation field estimator

### DIFF
--- a/symlens/qe.py
+++ b/symlens/qe.py
@@ -966,7 +966,7 @@ def rotation_response_f(XY,rev=False):
     Returns
     -------
 
-    f : :obj:`sympy.core.symbol.Symbol` , optional
+    f : :obj:`sympy.core.symbol.Symbol`
         A sympy expression containing the mode-coupling response. See the Usage guide
         for details.
 


### PR DESCRIPTION
I included an estimator for CMB polarization rotations following [Yadav et. al. 2009]( https://arxiv.org/abs/0902.4466v1). It should be the same as lensing apart from the mode-coupling constants. 


