### PR TITLE
bugfix: added term to shear estimator with l1 <--> l2 swapped

### DIFF
--- a/symlens/qe.py
+++ b/symlens/qe.py
@@ -1256,7 +1256,7 @@ def get_mc_expressions(estimator,XY,field_names=None,estimator_to_harden='hu_ok'
 
     elif estimator=='shear': # Schaan, Ferraro 2018
         assert XY=="TT", "Shear estimator only implemented for TT."
-        f = cLdl2*u2('TT')
+        f = cLdl2*u2('TT') + cLdl1*u1('TT')
         fr = cLdl1*u1('TT')
         cos2theta = ((2*(cLdl1)**2)/L**2/l1**2) - 1
         cos2theta_rev = ((2*(cLdl2)**2)/L**2/l2**2) - 1


### PR DESCRIPTION
Hi Mat. Thanks for making this great code available! I think I have found and corrected a small bug. The auto- and cross-spectra (with the true lensing potential) of shear reconstructions were previously biased low. With this bugfix, we recover the expected behaviour, while passing all existing tests. It might not be the fix that best fits the style of the code, but I hope it is a good starting point for a more elegant and permanent one.