### PR TITLE
Alex dev

### DIFF
--- a/bin/example_ardn0.py
+++ b/bin/example_ardn0.py
@@ -3,11 +3,14 @@ from orphics import maps,cosmology
 from pixell import enmap
 import numpy as np
 import os,sys
+
+sys.path.append('../')
+
 from symlens import qe
 
 # Say we want analytic RDN0 for the TTTE estimator
 XY='TT'
-UV='TE'
+UV='TT'
 
 # example geometry, you can use your own map's geometry
 shape,wcs = maps.rect_geometry(width_deg=5.,px_res_arcmin=2.0)

--- a/bin/example_ardn0.py
+++ b/bin/example_ardn0.py
@@ -4,13 +4,13 @@ from pixell import enmap
 import numpy as np
 import os,sys
 
-sys.path.append('../')
+
 
 from symlens import qe
 
 # Say we want analytic RDN0 for the TTTE estimator
 XY='TT'
-UV='TT'
+UV='TE'
 
 # example geometry, you can use your own map's geometry
 shape,wcs = maps.rect_geometry(width_deg=5.,px_res_arcmin=2.0)

--- a/bin/tau_bh_ave.py
+++ b/bin/tau_bh_ave.py
@@ -40,7 +40,7 @@ ells = np.arange(20,Lmax,1)
 binner = stats.bin2D(modlmap,bin_edges)
 clkk = theory.gCl('kk',ells)
 
-
+XY = 'TT'
 kmask = maps.mask_kspace(shape,wcs,lmin=20,lmax=Lmax)
 
 f_phi = s.Ldl1 * s.e('uC_T_T_l1') + s.Ldl2 * s.e('uC_T_T_l2')
@@ -55,8 +55,7 @@ expr1_tau = f_tau * F_tau
 
 feed_dict = {}
 feed_dict['uC_T_T'] = theory.uCl('TT',modlmap)
-# feed_dict['tC_T_T'] = theory.lCl('TT',modlmap) + (noise_level*np.pi/180/60)**2./maps.gauss_beam(modlmap,1.4)**2.
-feed_dict['tC_T_T'] = theory.lCl('TT',modlmap) + (noise_level*np.pi/180/60)**2.
+feed_dict['tC_T_T'] = theory.lCl('TT',modlmap) + (noise_level*np.pi/180/60)**2./maps.gauss_beam(modlmap,1.4)**2.
 
 feed_dict['pc_T_T'] = 1
 
@@ -88,13 +87,13 @@ N_l_phi = qe.N_l_optimal(shape,wcs,feed_dict,'hu_ok','TT',xmask=xmask,ymask=ymas
 print (feed_dict.keys())
 
 
-h_phi_srcbh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
-                            Al=None,estimator=estimator,hardening=hardening)
+h_phi_srcbh = qe.HardenedXY(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                            Al=None,estimator=estimator,hardening=hardening, XY=XY)
 N_l_phi_srcbh = h_phi_srcbh.get_Nl()
 print (feed_dict.keys())
 
-h_phi_maskbh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
-                            Al=None,estimator='hu_ok', hardening='mask')
+h_phi_maskbh = qe.HardenedXY(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                             Al=None,estimator='hu_ok', hardening='mask', XY=XY)
 
 
 
@@ -108,15 +107,13 @@ print('check, ', feed_dict.keys())
 
 
 
-h_mask_phibh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
-                            Al=None,estimator='mask', hardening='phi', target = 'mask')
+h_mask_phibh = qe.HardenedXY(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                             Al=None,estimator='mask', hardening='phi', target = 'mask',XY=XY)
 
-h_tau_phibh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
-                            Al=None,estimator='tau', hardening='phi', target = 'tau')
+h_tau_phibh = qe.HardenedXY(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                            Al=None,estimator='tau', hardening='phi', target = 'tau',XY=XY)
 
-if False:
-    h_tau_phibh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
-                                Al=None,estimator='mask', hardening='phi', target = 'tau')
+
 
 N_l_mask_phibh = h_mask_phibh.get_Nl()
 N_l_tau_phibh = h_tau_phibh.get_Nl()

--- a/bin/tau_bh_ave.py
+++ b/bin/tau_bh_ave.py
@@ -1,0 +1,169 @@
+from __future__ import print_function
+from orphics import maps,io,cosmology,stats
+from pixell import enmap
+import numpy as np
+import os,sys
+from symlens import qe
+from symlens.factorize import e
+import symlens as s
+
+shape,wcs = maps.rect_geometry(width_deg=20.,px_res_arcmin=1.5,proj='plain')
+theory = cosmology.default_theory()
+modlmap = enmap.modlmap(shape,wcs)
+
+hardening = 'src'
+
+noise_level = 10.
+
+# Lmax = 2000
+# cluster = False
+
+Lmax = 6000
+cluster = False
+
+if cluster:
+    xmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=2000)
+    ymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=6000)
+    lxmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=2000)
+    lymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=6000)
+    estimator = 'hdv'
+else:
+    xmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=3500)
+    ymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=3500)
+    lxmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=3500)
+    lymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=3500)
+    estimator = 'hu_ok'
+
+
+bin_edges = np.arange(20,Lmax,20)
+ells = np.arange(20,Lmax,1)
+binner = stats.bin2D(modlmap,bin_edges)
+clkk = theory.gCl('kk',ells)
+
+
+kmask = maps.mask_kspace(shape,wcs,lmin=20,lmax=Lmax)
+
+f_phi = s.Ldl1 * s.e('uC_T_T_l1') + s.Ldl2 * s.e('uC_T_T_l2')
+F_phi = f_phi / 2 / s.e('tC_T_T_l1') / s.e('tC_T_T_l2')
+
+expr1_phi = f_phi * F_phi
+
+f_tau = s.e('uC_T_T_l1') +  s.e('uC_T_T_l2')
+F_tau = f_tau / 2 / s.e('tC_T_T_l1') / s.e('tC_T_T_l2')
+
+expr1_tau = f_tau * F_tau
+
+feed_dict = {}
+feed_dict['uC_T_T'] = theory.uCl('TT',modlmap)
+feed_dict['tC_T_T'] = theory.lCl('TT',modlmap) + (noise_level*np.pi/180/60)**2./maps.gauss_beam(modlmap,1.4)**2.
+feed_dict['pc_T_T'] = 1
+
+
+# res_phi = s.integrate(shape,wcs,feed_dict,expr1_phi,xmask=xmask,ymask=xmask).real
+
+# res_tau = s.integrate(shape,wcs,feed_dict,expr1_tau,xmask=xmask,ymask=xmask).real
+
+A_L_phi = qe.A_l_custom(shape, wcs, feed_dict, f_phi, F_phi, xmask=xmask, ymask=ymask)
+print( feed_dict.keys())
+A_L_phi_predef = qe.A_l(shape,wcs,feed_dict,'hu_ok','TT',xmask=xmask,ymask=ymask)
+print(feed_dict.keys())
+A_L_tau = qe.A_l_custom(shape, wcs, feed_dict, f_tau, F_tau, xmask=xmask, ymask=ymask)
+print(feed_dict.keys())
+A_L_mask_predef = qe.A_l(shape, wcs, feed_dict, 'mask', 'TT', xmask=xmask,ymask=ymask)
+print( feed_dict.keys())
+# my_qe_phi = qe.QE(shape, wcs, feed_dict, 'hu_ok', XY = 'TT', 
+#                   f = f_phi, F = F_phi, xmask = xmask, ymask = ymask)
+
+
+N_l_phi = qe.N_l_optimal(shape,wcs,feed_dict,'hu_ok','TT',xmask=lxmask,ymask=lymask,field_names=None,kmask=kmask)
+print (feed_dict.keys())
+
+
+h_phi_srcbh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                            Al=None,estimator=estimator,hardening=hardening)
+N_l_phi_srcbh = h_phi_srcbh.get_Nl()
+print (feed_dict.keys())
+
+h_phi_taubh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                            Al=None,estimator='hu_ok', hardening='mask')
+
+
+# N_l = qe.N_l_optimal(shape,wcs,feed_dict,'hu_ok','TT',xmask=lxmask,ymask=lymask,field_names=None,kmask=kmask)
+N_l_mask = qe.N_l_optimal(shape,wcs,feed_dict,'mask','TT',xmask=lxmask,ymask=lymask,field_names=None,kmask=kmask)
+
+print('check, ', feed_dict.keys())
+
+
+h_mask_phibh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                            Al=None,estimator='mask', hardening='phi', target = 'mask')
+
+N_l_mask_phibh = h_mask_phibh.get_Nl()
+
+
+
+
+
+# h_phi_srcbh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+#                             Al=None,estimator=estimator,hardening=hardening)
+
+
+# h_tau_phibh = qe.HardenedTT
+
+#print(binner.bin(anull)[1])
+
+
+cents, A_L_phi_1d = binner.bin(A_L_phi )
+cents, A_L_phi_predef_1d = binner.bin(A_L_phi_predef)
+
+cents, A_L_tau_1d = binner.bin(A_L_tau)
+cents, A_L_mask_predef_1d = binner.bin(A_L_mask_predef)
+
+cents, N_L_phi_1d = binner.bin(N_l_phi)
+cents, N_L_phi_srcbh_1d = binner.bin(N_l_phi_srcbh)
+
+cents, N_L_mask_1d = binner.bin(N_l_mask)
+cents, N_L_mask_phibh_1d = binner.bin(N_l_mask_phibh)
+
+pl = io.Plotter('CL',xyscale='loglog')
+pl.add(cents,A_L_phi_1d * cents**2)
+pl.add(cents,A_L_phi_predef_1d * cents**2, ls='--')
+# pl.hline(y=1)
+pl.done('../output/A_L_phi.png')
+
+
+
+pl = io.Plotter('L',xyscale='loglog')
+# pl.add(cents,A_L_tau_1d , label = 'A_L_tau_1d')
+# pl.add(cents,A_L_mask_predef_1d, label = 'A_L_mask_predef_1d')
+pl.add(cents,N_L_mask_1d * 4 / cents**2, label = 'N_L_mask_1d')
+pl.add(cents,N_L_mask_phibh_1d * 4 / cents**2, label = 'N_L_mask_phibh_1d', ls = '--')
+
+
+pl.legend(loc = 'best')
+# pl.hline(y=1)
+pl.done('../output/A_L_tau.png')
+
+
+
+
+pl = io.Plotter('CL',xyscale='loglog')
+pl.add(ells,clkk,color='k')
+pl.add(cents,N_L_phi_1d,ls='--')
+pl.add(cents,N_L_phi_srcbh_1d,ls=':')
+pl._ax.set_ylim(1e-8,5e-4)
+pl.done('../output/phi_bh.png')
+
+
+# pl = io.Plotter('rCL',xyscale='liN_Lin')
+# pl.add(cents,N_Lbh1d/N_L1d)
+# pl.hline(y=1)
+# pl.done('../output/bhdiff.png')
+
+
+cents, ALsrc1d = binner.bin(h_phi_srcbh.fdict['Asrc_src_L'] )
+pl = io.Plotter('CL',xyscale='linlog')
+pl.add(cents,ALsrc1d / cents**2)
+# pl.hline(y=1)
+pl.done('../output/A_L_src.png')
+
+

--- a/bin/tau_bh_ave.py
+++ b/bin/tau_bh_ave.py
@@ -55,7 +55,9 @@ expr1_tau = f_tau * F_tau
 
 feed_dict = {}
 feed_dict['uC_T_T'] = theory.uCl('TT',modlmap)
-feed_dict['tC_T_T'] = theory.lCl('TT',modlmap) + (noise_level*np.pi/180/60)**2./maps.gauss_beam(modlmap,1.4)**2.
+# feed_dict['tC_T_T'] = theory.lCl('TT',modlmap) + (noise_level*np.pi/180/60)**2./maps.gauss_beam(modlmap,1.4)**2.
+feed_dict['tC_T_T'] = theory.lCl('TT',modlmap) + (noise_level*np.pi/180/60)**2.
+
 feed_dict['pc_T_T'] = 1
 
 
@@ -71,11 +73,16 @@ A_L_tau = qe.A_l_custom(shape, wcs, feed_dict, f_tau, F_tau, xmask=xmask, ymask=
 print(feed_dict.keys())
 A_L_mask_predef = qe.A_l(shape, wcs, feed_dict, 'mask', 'TT', xmask=xmask,ymask=ymask)
 print( feed_dict.keys())
+
+A_L_tau_predef = qe.A_l(shape, wcs, feed_dict, 'tau', 'TT', xmask=xmask,ymask=ymask)
+print( feed_dict.keys())
+
+
 # my_qe_phi = qe.QE(shape, wcs, feed_dict, 'hu_ok', XY = 'TT', 
 #                   f = f_phi, F = F_phi, xmask = xmask, ymask = ymask)
 
 
-N_l_phi = qe.N_l_optimal(shape,wcs,feed_dict,'hu_ok','TT',xmask=lxmask,ymask=lymask,field_names=None,kmask=kmask)
+N_l_phi = qe.N_l_optimal(shape,wcs,feed_dict,'hu_ok','TT',xmask=xmask,ymask=ymask,field_names=None,kmask=kmask)
 print (feed_dict.keys())
 
 
@@ -84,18 +91,24 @@ h_phi_srcbh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=km
 N_l_phi_srcbh = h_phi_srcbh.get_Nl()
 print (feed_dict.keys())
 
-h_phi_taubh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+h_phi_maskbh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
                             Al=None,estimator='hu_ok', hardening='mask')
 
 
 # N_l = qe.N_l_optimal(shape,wcs,feed_dict,'hu_ok','TT',xmask=lxmask,ymask=lymask,field_names=None,kmask=kmask)
-N_l_mask = qe.N_l_optimal(shape,wcs,feed_dict,'mask','TT',xmask=lxmask,ymask=lymask,field_names=None,kmask=kmask)
+N_l_mask = qe.N_l_optimal(shape,wcs,feed_dict,'mask','TT',xmask=xmask,ymask=ymask,field_names=None,kmask=kmask)
+
+N_l_tau = qe.N_l_optimal(shape,wcs,feed_dict,'tau','TT',xmask=xmask,ymask=ymask,field_names=None,kmask=kmask)
+
 
 print('check, ', feed_dict.keys())
 
 
+
 h_mask_phibh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
                             Al=None,estimator='mask', hardening='phi', target = 'mask')
+h_tau_phibh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                            Al=None,estimator='mask', hardening='phi', target = 'tau')
 
 N_l_mask_phibh = h_mask_phibh.get_Nl()
 
@@ -116,13 +129,22 @@ cents, A_L_phi_1d = binner.bin(A_L_phi )
 cents, A_L_phi_predef_1d = binner.bin(A_L_phi_predef)
 
 cents, A_L_tau_1d = binner.bin(A_L_tau)
+
 cents, A_L_mask_predef_1d = binner.bin(A_L_mask_predef)
+
+cents, A_L_tau_predef_1d = binner.bin(A_L_tau_predef)
+
+cents, A_L_mask_predef_1d = binner.bin(A_L_mask_predef)
+
 
 cents, N_L_phi_1d = binner.bin(N_l_phi)
 cents, N_L_phi_srcbh_1d = binner.bin(N_l_phi_srcbh)
 
 cents, N_L_mask_1d = binner.bin(N_l_mask)
+cents, N_L_tau_1d = binner.bin(N_l_tau)
+
 cents, N_L_mask_phibh_1d = binner.bin(N_l_mask_phibh)
+
 
 pl = io.Plotter('CL',xyscale='loglog')
 pl.add(cents,A_L_phi_1d * cents**2)
@@ -133,10 +155,16 @@ pl.done('../output/A_L_phi.png')
 
 
 pl = io.Plotter('L',xyscale='loglog')
-# pl.add(cents,A_L_tau_1d , label = 'A_L_tau_1d')
-# pl.add(cents,A_L_mask_predef_1d, label = 'A_L_mask_predef_1d')
-pl.add(cents,N_L_mask_1d * 4 / cents**2, label = 'N_L_mask_1d')
-pl.add(cents,N_L_mask_phibh_1d * 4 / cents**2, label = 'N_L_mask_phibh_1d', ls = '--')
+pl.add(cents,A_L_tau_1d , label = 'A_L_tau_1d', color = 'b')
+pl.add(cents,A_L_tau_predef_1d , label = 'A_L_tau_predef_1d', color = 'b', ls = 'dashed')
+
+pl.add(cents,A_L_mask_predef_1d, label = 'A_L_mask_predef_1d', color = 'r', ls = 'dashed')
+
+pl.add(cents,N_L_tau_1d * 4 / cents**2, label = 'N_L_tau_1d' , color = 'b', ls = 'dashdot')
+
+pl.add(cents,N_L_mask_1d * 4 / cents**2, label = 'N_L_mask_1d', color = 'r', ls = 'dashdot')
+pl.add(cents,N_L_mask_phibh_1d * 4 / cents**2, label = 'N_L_mask_phibh_1d', color = 'r',
+       ls = 'dotted')
 
 
 pl.legend(loc = 'best')

--- a/bin/tau_bh_ave.py
+++ b/bin/tau_bh_ave.py
@@ -74,6 +74,8 @@ print(feed_dict.keys())
 A_L_mask_predef = qe.A_l(shape, wcs, feed_dict, 'mask', 'TT', xmask=xmask,ymask=ymask)
 print( feed_dict.keys())
 
+# import pdb
+# pdb.set_trace()
 A_L_tau_predef = qe.A_l(shape, wcs, feed_dict, 'tau', 'TT', xmask=xmask,ymask=ymask)
 print( feed_dict.keys())
 
@@ -95,6 +97,7 @@ h_phi_maskbh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=k
                             Al=None,estimator='hu_ok', hardening='mask')
 
 
+
 # N_l = qe.N_l_optimal(shape,wcs,feed_dict,'hu_ok','TT',xmask=lxmask,ymask=lymask,field_names=None,kmask=kmask)
 N_l_mask = qe.N_l_optimal(shape,wcs,feed_dict,'mask','TT',xmask=xmask,ymask=ymask,field_names=None,kmask=kmask)
 
@@ -107,10 +110,16 @@ print('check, ', feed_dict.keys())
 
 h_mask_phibh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
                             Al=None,estimator='mask', hardening='phi', target = 'mask')
+
 h_tau_phibh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
-                            Al=None,estimator='mask', hardening='phi', target = 'tau')
+                            Al=None,estimator='tau', hardening='phi', target = 'tau')
+
+if False:
+    h_tau_phibh = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                                Al=None,estimator='mask', hardening='phi', target = 'tau')
 
 N_l_mask_phibh = h_mask_phibh.get_Nl()
+N_l_tau_phibh = h_tau_phibh.get_Nl()
 
 
 
@@ -144,6 +153,7 @@ cents, N_L_mask_1d = binner.bin(N_l_mask)
 cents, N_L_tau_1d = binner.bin(N_l_tau)
 
 cents, N_L_mask_phibh_1d = binner.bin(N_l_mask_phibh)
+cents, N_L_tau_phibh_1d = binner.bin(N_l_tau_phibh)
 
 
 pl = io.Plotter('CL',xyscale='loglog')
@@ -161,6 +171,7 @@ pl.add(cents,A_L_tau_predef_1d , label = 'A_L_tau_predef_1d', color = 'b', ls = 
 pl.add(cents,A_L_mask_predef_1d, label = 'A_L_mask_predef_1d', color = 'r', ls = 'dashed')
 
 pl.add(cents,N_L_tau_1d * 4 / cents**2, label = 'N_L_tau_1d' , color = 'b', ls = 'dashdot')
+pl.add(cents,N_L_tau_phibh_1d * 4 / cents**2, label = 'N_L_tau_phibh_1d' , color = 'b', ls = 'dotted')
 
 pl.add(cents,N_L_mask_1d * 4 / cents**2, label = 'N_L_mask_1d', color = 'r', ls = 'dashdot')
 pl.add(cents,N_L_mask_phibh_1d * 4 / cents**2, label = 'N_L_mask_phibh_1d', color = 'r',

--- a/bin/tau_bh_ave_pol.py
+++ b/bin/tau_bh_ave_pol.py
@@ -13,7 +13,7 @@ shape,wcs = maps.rect_geometry(width_deg=20.,px_res_arcmin=1.5,proj='plain')
 theory = cosmology.default_theory()
 modlmap = enmap.modlmap(shape,wcs)
 
-hardening = 'src'
+#hardening = 'src'
 
 noise_level = 1.
 
@@ -175,26 +175,4 @@ for ii, XY in enumerate(XYs):
     np.savetxt('../output/nl_tau_%s_lmax%i.txt' % (XY, lmax), np.transpose([cents, N_L_tau_1d[XY], N_L_tau_phibh_1d[XY]]), 
                header = " ell, N_L_tau, N_L_tau_bh")
 stop
-
-
-pl = io.Plotter('CL',xyscale='loglog')
-pl.add(ells,clkk,color='k')
-pl.add(cents,N_L_phi_1d,ls='--')
-pl.add(cents,N_L_phi_srcbh_1d,ls=':')
-pl._ax.set_ylim(1e-8,5e-4)
-pl.done('../output/phi_bh.png')
-
-
-# pl = io.Plotter('rCL',xyscale='liN_Lin')
-# pl.add(cents,N_Lbh1d/N_L1d)
-# pl.hline(y=1)
-# pl.done('../output/bhdiff.png')
-
-
-cents, ALsrc1d = binner.bin(h_phi_srcbh.fdict['Asrc_src_L'] )
-pl = io.Plotter('CL',xyscale='linlog')
-pl.add(cents,ALsrc1d / cents**2)
-# pl.hline(y=1)
-pl.done('../output/A_L_src.png')
-
 

--- a/bin/tau_bh_ave_pol.py
+++ b/bin/tau_bh_ave_pol.py
@@ -1,0 +1,200 @@
+from __future__ import print_function
+from orphics import maps,io,cosmology,stats
+from pixell import enmap
+import numpy as np
+import os,sys
+from symlens import qe
+from symlens.factorize import e
+import symlens as s
+
+import matplotlib.pyplot as plt
+
+shape,wcs = maps.rect_geometry(width_deg=20.,px_res_arcmin=1.5,proj='plain')
+theory = cosmology.default_theory()
+modlmap = enmap.modlmap(shape,wcs)
+
+hardening = 'src'
+
+noise_level = 1.
+
+# Lmax = 2000
+# cluster = False
+
+Lmax = 5100
+beam_arcmin = 1.0
+
+delensing_amp_factor = 0.2 #assumed reduction factor for delensing, sometimes called A_L
+
+
+cluster = False
+
+if cluster:
+    xmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=2000)
+    ymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=6000)
+    lxmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=2000)
+    lymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=6000)
+    estimator = 'hdv'
+else:
+    lmax = 5000
+    lmin = 30
+    xmask = maps.mask_kspace(shape,wcs,lmin=lmin,lmax=lmax)
+    ymask = maps.mask_kspace(shape,wcs,lmin=lmin,lmax=lmax)
+    lxmask = maps.mask_kspace(shape,wcs,lmin=lmin,lmax=lmax)
+    lymask = maps.mask_kspace(shape,wcs,lmin=lmin,lmax=lmax)
+    estimator = 'hu_ok'
+
+    
+
+
+bin_edges = np.arange(20,Lmax,20)
+ells = np.arange(20,Lmax,1)
+binner = stats.bin2D(modlmap,bin_edges)
+clkk = theory.gCl('kk',ells)
+
+# XYs = ['TT', 'EB']
+XYs = ['TT', 'EB']
+
+kmask = maps.mask_kspace(shape,wcs,lmin=20,lmax=Lmax)
+
+feed_dict = {}
+feed_dict['uC_T_T'] = theory.uCl('TT',modlmap)
+feed_dict['tC_T_T'] = theory.lCl('TT',modlmap) + (noise_level*np.pi/180/60)**2./maps.gauss_beam(modlmap,beam_arcmin)**2.
+
+feed_dict['uC_E_E'] = theory.uCl('EE',modlmap)
+feed_dict['tC_E_E'] = theory.lCl('EE',modlmap) + 2 * (noise_level*np.pi/180/60)**2./maps.gauss_beam(modlmap,beam_arcmin)**2.
+
+
+feed_dict['uC_B_B'] = theory.uCl('BB',modlmap) #this should just be zero
+feed_dict['tC_B_B'] = theory.lCl('BB',modlmap) * delensing_amp_factor \
+                      + 2 * (noise_level*np.pi/180/60)**2./maps.gauss_beam(modlmap,beam_arcmin)**2.
+
+feed_dict['pc_T_T'] = 1
+
+
+do_all = True
+if do_all:
+    A_L_phi_predef_1d = {}
+
+    A_L_mask_predef_1d = {}
+
+    A_L_tau_predef_1d = {}
+
+    N_L_phi_1d  = {}
+    N_L_phi_srcbh_1d = {}
+
+    N_L_mask_1d  = {}
+    N_L_tau_1d  = {}
+
+    N_L_mask_phibh_1d = {}
+    N_L_tau_phibh_1d = {}
+
+
+
+
+    for XY in XYs:
+
+        A_L_phi_predef = qe.A_l(shape,wcs,feed_dict,'hu_ok',XY,xmask=xmask,ymask=ymask)
+
+
+        # A_L_mask_predef = qe.A_l(shape, wcs, feed_dict, 'mask', XY, xmask=xmask,ymask=ymask)
+
+        A_L_tau_predef = qe.A_l(shape, wcs, feed_dict, 'tau', XY, xmask=xmask,ymask=ymask)
+
+        N_l_phi = qe.N_l_optimal(shape,wcs,feed_dict,'hu_ok',XY,
+                                 xmask=xmask,ymask=ymask,field_names=None,kmask=kmask)
+
+
+
+        # h_phi_srcbh = qe.HardenedXY(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+        #                             Al=None,estimator=estimator,hardening=hardening, XY=XY)
+        # N_l_phi_srcbh = h_phi_srcbh.get_Nl()
+
+
+        # h_phi_maskbh = qe.HardenedXY(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+        #                              Al=None,estimator='hu_ok', hardening='mask', XY=XY)
+
+
+
+        # N_l_mask = qe.N_l_optimal(shape,wcs,feed_dict,'mask','TT',xmask=xmask,ymask=ymask,
+        #                           field_names=None,kmask=kmask)
+
+        N_l_tau = qe.N_l_optimal(shape,wcs,feed_dict,'tau',XY,xmask=xmask,ymask=ymask,
+                                 field_names=None,kmask=kmask)
+
+
+        # h_mask_phibh = qe.HardenedXY(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+        #                              Al=None,estimator='mask', hardening='phi', target = 'mask',XY=XY)
+
+        # import pdb as PDB
+        # PDB.set_trace()
+        h_tau_phibh = qe.HardenedXY(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,
+                                    Al=None,estimator='tau', hardening='phi', target = 'tau',XY=XY)
+
+
+
+        # N_l_mask_phibh = h_mask_phibh.get_Nl()
+        N_l_tau_phibh = h_tau_phibh.get_Nl()
+
+        cents, A_L_phi_predef_1d[XY] = binner.bin(A_L_phi_predef)
+
+        # cents, A_L_mask_predef_1d[XY] = binner.bin(A_L_mask_predef)
+
+        cents, A_L_tau_predef_1d[XY] = binner.bin(A_L_tau_predef)
+
+
+        cents, N_L_phi_1d[XY] = binner.bin(N_l_phi)
+        # cents, N_L_phi_srcbh_1d[XY] = binner.bin(N_l_phi_srcbh)
+
+        # cents, N_L_mask_1d[XY] = binner.bin(N_l_mask)
+        cents, N_L_tau_1d[XY] = binner.bin(N_l_tau)
+
+        # cents, N_L_mask_phibh_1d[XY] = binner.bin(N_l_mask_phibh)
+        cents, N_L_tau_phibh_1d[XY] = binner.bin(N_l_tau_phibh)
+
+
+
+
+
+
+for ii, XY in enumerate(XYs):
+    plt.figure(figsize=(5,5))
+
+    prefac = 1/cents**2
+    plt.semilogy(cents,prefac * A_L_tau_predef_1d[XY] , label = 'A_L_tau_predef_1d', color = 'b', ls = 'dashed')
+
+
+    plt.semilogy(cents,prefac * N_L_tau_1d[XY] * 4 / cents**2, label = 'N_L_tau_1d' , color = 'b', ls = 'dashdot')
+    plt.semilogy(cents,prefac * N_L_tau_phibh_1d[XY] * 4 / cents**2, label = 'N_L_tau_phibh_1d' , color = 'b', ls = 'dotted')
+
+    plt.legend(loc = 'best')
+    # pl.hline(y=1)
+    plt.ylim([1e-14,1e0])
+    plt.xlim([0,5e3])
+    plt.savefig('../output/A_L_tau_%s_lmax%i.png' % (XY, lmax))
+
+    np.savetxt('../output/nl_tau_%s_lmax%i.txt' % (XY, lmax), np.transpose([cents, N_L_tau_1d[XY], N_L_tau_phibh_1d[XY]]), 
+               header = " ell, N_L_tau, N_L_tau_bh")
+stop
+
+
+pl = io.Plotter('CL',xyscale='loglog')
+pl.add(ells,clkk,color='k')
+pl.add(cents,N_L_phi_1d,ls='--')
+pl.add(cents,N_L_phi_srcbh_1d,ls=':')
+pl._ax.set_ylim(1e-8,5e-4)
+pl.done('../output/phi_bh.png')
+
+
+# pl = io.Plotter('rCL',xyscale='liN_Lin')
+# pl.add(cents,N_Lbh1d/N_L1d)
+# pl.hline(y=1)
+# pl.done('../output/bhdiff.png')
+
+
+cents, ALsrc1d = binner.bin(h_phi_srcbh.fdict['Asrc_src_L'] )
+pl = io.Plotter('CL',xyscale='linlog')
+pl.add(cents,ALsrc1d / cents**2)
+# pl.hline(y=1)
+pl.done('../output/A_L_src.png')
+
+

--- a/bin/test_bh_ave.py
+++ b/bin/test_bh_ave.py
@@ -58,18 +58,19 @@ pl.add(ells,clkk,color='k')
 pl.add(cents,nl1d,ls='--')
 pl.add(cents,nlbh1d,ls=':')
 pl._ax.set_ylim(1e-8,5e-4)
-pl.done('bh.png')
+pl.done('../output/bh.png')
 
 
 pl = io.Plotter('rCL',xyscale='linlin')
 pl.add(cents,nlbh1d/nl1d)
 pl.hline(y=1)
-pl.done('bhdiff.png')
+pl.done('../output/bhdiff.png')
 
+print('hi')
 cents, ALsrc1d = binner.bin(h.fdict['Asrc_src_L'] )
 pl = io.Plotter('CL',xyscale='linlog')
-pl.add(cents,ALsrc1d)
+pl.add(cents,ALsrc1d / cents**2)
 # pl.hline(y=1)
-pl.done('A_L_src.png')
+pl.done('../output/A_L_src.png')
 
 

--- a/bin/test_bh_ave.py
+++ b/bin/test_bh_ave.py
@@ -1,0 +1,75 @@
+from __future__ import print_function
+from orphics import maps,io,cosmology,stats
+from pixell import enmap
+import numpy as np
+import os,sys
+from symlens import qe
+from symlens.factorize import e
+
+shape,wcs = maps.rect_geometry(width_deg=20.,px_res_arcmin=1.5,proj='plain')
+theory = cosmology.default_theory()
+modlmap = enmap.modlmap(shape,wcs)
+
+hardening = 'src'
+
+noise_level = 10.
+
+# Lmax = 2000
+# cluster = False
+
+Lmax = 6000
+cluster = False
+
+if cluster:
+    xmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=2000)
+    ymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=6000)
+    lxmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=2000)
+    lymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=6000)
+    estimator = 'hdv'
+else:
+    xmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=3500)
+    ymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=3500)
+    lxmask = maps.mask_kspace(shape,wcs,lmin=100,lmax=3500)
+    lymask = maps.mask_kspace(shape,wcs,lmin=100,lmax=3500)
+    estimator = 'hu_ok'
+
+kmask = maps.mask_kspace(shape,wcs,lmin=20,lmax=Lmax)
+
+feed_dict = {}
+feed_dict['uC_T_T'] = theory.uCl('TT',modlmap)
+feed_dict['tC_T_T'] = theory.lCl('TT',modlmap) + (noise_level*np.pi/180/60)**2./maps.gauss_beam(modlmap,1.4)**2.
+feed_dict['pc_T_T'] = 1
+
+N_l = qe.N_l_optimal(shape,wcs,feed_dict,'hu_ok','TT',xmask=lxmask,ymask=lymask,field_names=None,kmask=kmask)
+h = qe.HardenedTT(shape,wcs,feed_dict,xmask=xmask,ymask=ymask,kmask=kmask,Al=None,estimator=estimator,hardening=hardening)
+N_l_bh = h.get_Nl()
+    
+bin_edges = np.arange(20,Lmax,20)
+ells = np.arange(20,Lmax,1)
+binner = stats.bin2D(modlmap,bin_edges)
+clkk = theory.gCl('kk',ells)
+
+#print(binner.bin(anull)[1])
+
+cents,nl1d = binner.bin(N_l)
+cents,nlbh1d = binner.bin(N_l_bh)
+pl = io.Plotter('CL',xyscale='loglog')
+pl.add(ells,clkk,color='k')
+pl.add(cents,nl1d,ls='--')
+pl.add(cents,nlbh1d,ls=':')
+pl._ax.set_ylim(1e-8,5e-4)
+pl.done('bh.png')
+
+
+pl = io.Plotter('rCL',xyscale='linlin')
+pl.add(cents,nlbh1d/nl1d)
+pl.hline(y=1)
+pl.done('bhdiff.png')
+
+cents, ALsrc1d = binner.bin(h.fdict['Asrc_src_L'] )
+pl = io.Plotter('CL',xyscale='linlog')
+pl.add(cents,ALsrc1d)
+# pl.hline(y=1)
+pl.done('A_L_src.png')
+
+


### PR DESCRIPTION
- New 'mod' mode coupling coded into qe.py - for "mask bias hardening" or "patchy tau" estimation (note these are mathematically almost the same but have opposite sign, and differ in whether the modulated field includes noise)
- The HardenedTT class has been generalized so that the field that one is measuring is general and is no longer assumed to be 'phi' or lensing.  This involved removing a few spots where lensing is assumed to be the target mode-coupling.  The examples in the new scripts are for the 'mod' mode-coupling, in which one wants to bias-harden lensing out of the estimate for tau
-  A new HardenedXY class has been written to allow for bias hardening in cases other than TT.   This is basically a duplicate of the HardenedTT class -- ideally that would just be a subset of this new one to avoid all the copied code.  This allows for, e.g. hardening phi(EB) from the estimate of tau(EB)
